### PR TITLE
chore(pyproject): update license for PEP639 and new repo location

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,8 @@
 [project]
 name = "buildcatrust"
 requires-python = ">=3.11"
-license.file = "LICENSES/MIT.txt"
+license = "MIT"
+license-files = ["LICENSES/*.txt", "AUTHORS"]
 readme = "README.md"
 authors = [
     {name = "Luke Granger-Brown", email = "buildcatrust@lukegb.com"},
@@ -13,9 +14,6 @@ authors = [
 ]
 maintainers = [
     {name = "Luke Granger-Brown", email = "buildcatrust@lukegb.com"},
-]
-classifiers = [
-    "License :: OSI Approved :: MIT License",
 ]
 dynamic = ["description", "version"]
 
@@ -26,7 +24,7 @@ Source = "https://github.com/lukegb/buildcatrust"
 buildcatrust = "buildcatrust.cli:main"
 
 [build-system]
-requires = ["flit_core >=2,<4"]
+requires = ["flit_core >=3.12,<4"]
 build-backend = "flit_core.buildapi"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ maintainers = [
 dynamic = ["description", "version"]
 
 [project.urls]
-Source = "https://github.com/lukegb/buildcatrust"
+Source = "https://github.com/nix-community/buildcatrust"
 
 [project.scripts]
 buildcatrust = "buildcatrust.cli:main"


### PR DESCRIPTION
The repo has moved under the nix-community org, and [PEP 639](https://peps.python.org/pep-0639/) specifies a new format for license information in pyproject.toml.